### PR TITLE
:tada: Bump to 0.1.0.alpha

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [tool.poetry]
 authors = ["Jean-Christophe Bianic <jc.bianic@gmail.com>"]
 classifiers = [
-  "Development Status :: 1 - Planning",
+  "Development Status :: 4 - Beta",
   "Environment :: Web Environment",
   "Framework :: Flask",
+  "Framework :: Pydantic",
   "License :: OSI Approved :: MIT License",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
@@ -21,14 +22,14 @@ classifiers = [
   "Topic :: Internet",
   "Typing :: Typed",
 ]
-description = "Bringing FastAPI Developer experience to Flask."
+description = "A Flask extension, inspired by FastAPI that uses Pydantic to provide easy-to-configure data validation for request parsing and response serialization."
 documentation = "https://flask-jeroboam.readthedocs.io"
 homepage = "https://github.com/jcbianic/flask-jeroboam"
 license = "MIT"
 name = "flask-jeroboam"
 readme = "README.md"
 repository = "https://github.com/jcbianic/flask-jeroboam"
-version = "0.0.3.alpha"
+version = "0.1.0.beta"
 
 [tool.poetry.urls]
 Changelog = "https://github.com/jcbianic/flask-jeroboam/releases"


### PR DESCRIPTION
Release the alpha version of 0.1.0. This is the first version to be a credible alternative to migrating your Flask app to FastAPI.