### PR TITLE
chore: activate ruff C4/C90 rules and fix stray E501 (#137)

### DIFF
--- a/flask_jeroboam/view_arguments/solved.py
+++ b/flask_jeroboam/view_arguments/solved.py
@@ -130,7 +130,7 @@ class SolvedArgument:
         return values, errors
 
     def _format_error(self, err: dict) -> dict:
-        """Format a single pydantic ValidationError entry into the Jeroboam error shape."""
+        """Format a pydantic ValidationError entry into the Jeroboam error shape."""
         loc = [self.location.value, self.alias] + [
             str(segment) for segment in err.get("loc", ())
         ]


### PR DESCRIPTION
## Summary

- C4 (flake8-comprehensions) and C90 (mccabe complexity) were already enabled on `release/0.2.2` as part of the xenon work — no violations exist
- Fixes a stray E501 (line too long) in `SolvedArgument._format_error` docstring that slipped through undetected

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)