### PR TITLE
release: 0.2.2

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,50 @@
+name: pre-commit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install Nox
+        run: uv tool install nox
+
+      - name: Compute pre-commit cache key
+        id: pre-commit-cache
+        shell: python
+        run: |
+          import hashlib
+          import sys
+          import os
+
+          python = "py{}.{}".format(*sys.version_info[:2])
+          payload = sys.version.encode() + sys.executable.encode()
+          digest = hashlib.sha256(payload).hexdigest()
+          result = "${{ runner.os }}-{}-{}-pre-commit".format(python, digest[:8])
+
+          if "GITHUB_OUTPUT" in os.environ:
+            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                print(f"result={result}", file=f)
+
+      - name: Restore pre-commit cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ steps.pre-commit-cache.outputs.result }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ steps.pre-commit-cache.outputs.result }}-
+
+      - name: Run pre-commit
+        run: nox --session=pre-commit --python=3.13

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,11 @@ name: pre-commit
 
 on:
   push:
+    branches: ["main"]
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   pre-commit:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard
+
+on:
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: "30 1 * * 1"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,12 +20,6 @@ jobs:
           - {
               python: "3.13",
               os: "ubuntu-latest",
-              session: "pre-commit",
-              upload: false,
-            }
-          - {
-              python: "3.13",
-              os: "ubuntu-latest",
               session: "mypy",
               upload: false,
             }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,6 +122,12 @@ jobs:
           - {
               python: "3.13",
               os: "ubuntu-latest",
+              session: "xenon",
+              upload: false,
+            }
+          - {
+              python: "3.13",
+              os: "ubuntu-latest",
               session: "docs-build",
               upload: false,
             }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,33 +145,6 @@ jobs:
       - name: Install Nox
         run: uv tool install nox
 
-      - name: Compute pre-commit cache key
-        if: matrix.session == 'pre-commit'
-        id: pre-commit-cache
-        shell: python
-        run: |
-          import hashlib
-          import sys
-          import os
-
-          python = "py{}.{}".format(*sys.version_info[:2])
-          payload = sys.version.encode() + sys.executable.encode()
-          digest = hashlib.sha256(payload).hexdigest()
-          result = "${{ runner.os }}-{}-{}-pre-commit".format(python, digest[:8])
-
-          if "GITHUB_OUTPUT" in os.environ:
-            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-                print(f"result={result}", file=f)
-
-      - name: Restore pre-commit cache
-        uses: actions/cache@v4
-        if: matrix.session == 'pre-commit'
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ steps.pre-commit-cache.outputs.result }}-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ steps.pre-commit-cache.outputs.result }}-
-
       - name: Run Nox
         run: nox --python=${{ matrix.python }}
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 [![Commit](https://img.shields.io/github/last-commit/jcbianic/flask-jeroboam?color=green)][commit]
 
 [![Read the documentation at https://flask-jeroboam.readthedocs.io/](https://img.shields.io/readthedocs/flask-jeroboam/latest.svg?label=Read%20the%20Docs)][read the docs]
-[![Coverage](https://codecov.io/gh/jcbianic/flask-jeroboam/graph/badge.svg)][codecov]
+[![Coverage](https://codecov.io/gh/jcbianic/flask-jeroboam/branch/main/graph/badge.svg)][codecov]
 [![Tests](https://github.com/jcbianic/flask-jeroboam/workflows/Tests/badge.svg)][tests]
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jcbianic/flask-jeroboam/badge)][scorecard]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 [![Read the documentation at https://flask-jeroboam.readthedocs.io/](https://img.shields.io/readthedocs/flask-jeroboam/latest.svg?label=Read%20the%20Docs)][read the docs]
 [![Coverage](https://codecov.io/gh/jcbianic/flask-jeroboam/branch/main/graph/badge.svg)][codecov]
 [![Tests](https://github.com/jcbianic/flask-jeroboam/workflows/Tests/badge.svg)][tests]
+[![pre-commit](https://github.com/jcbianic/flask-jeroboam/workflows/pre-commit/badge.svg)][pre-commit-ci]
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jcbianic/flask-jeroboam/badge)][scorecard]
 
@@ -36,6 +37,7 @@
 [tests]: https://github.com/jcbianic/flask-jeroboam/actions?workflow=Tests
 [codecov]: https://app.codecov.io/gh/jcbianic/flask-jeroboam
 [pre-commit]: https://github.com/pre-commit/pre-commit
+[pre-commit-ci]: https://github.com/jcbianic/flask-jeroboam/actions/workflows/pre-commit.yml
 [ruff]: https://github.com/astral-sh/ruff
 [scorecard]: https://scorecard.dev/viewer/?uri=github.com/jcbianic/flask-jeroboam
 [commit]: https://img.shields.io/github/last-commit/jcbianic/flask-jeroboam

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 [![Coverage](https://codecov.io/gh/jcbianic/flask-jeroboam/graph/badge.svg)][codecov]
 [![Tests](https://github.com/jcbianic/flask-jeroboam/workflows/Tests/badge.svg)][tests]
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jcbianic/flask-jeroboam/badge)][scorecard]
 
 [pypi_]: https://pypi.org/project/flask-jeroboam/
 [status]: https://pypi.org/project/flask-jeroboam/
@@ -36,6 +37,7 @@
 [codecov]: https://app.codecov.io/gh/jcbianic/flask-jeroboam
 [pre-commit]: https://github.com/pre-commit/pre-commit
 [ruff]: https://github.com/astral-sh/ruff
+[scorecard]: https://scorecard.dev/viewer/?uri=github.com/jcbianic/flask-jeroboam
 [commit]: https://img.shields.io/github/last-commit/jcbianic/flask-jeroboam
 
 </div>

--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@
 [![Commit](https://img.shields.io/github/last-commit/jcbianic/flask-jeroboam?color=green)][commit]
 
 [![Read the documentation at https://flask-jeroboam.readthedocs.io/](https://img.shields.io/readthedocs/flask-jeroboam/latest.svg?label=Read%20the%20Docs)][read the docs]
-[![Coverage](https://codecov.io/github/jcbianic/flask-jeroboam/graph/badge.svg)][codecov]
+[![Coverage](https://codecov.io/gh/jcbianic/flask-jeroboam/graph/badge.svg)][codecov]
 [![Tests](https://github.com/jcbianic/flask-jeroboam/workflows/Tests/badge.svg)][tests]
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/jcbianic/flask-jeroboam/main.svg)][pre-commit.ci]
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
 
 [pypi_]: https://pypi.org/project/flask-jeroboam/
@@ -36,7 +35,6 @@
 [tests]: https://github.com/jcbianic/flask-jeroboam/actions?workflow=Tests
 [codecov]: https://app.codecov.io/gh/jcbianic/flask-jeroboam
 [pre-commit]: https://github.com/pre-commit/pre-commit
-[pre-commit.ci]: https://results.pre-commit.ci/latest/github/jcbianic/flask-jeroboam/main
 [ruff]: https://github.com/astral-sh/ruff
 [commit]: https://img.shields.io/github/last-commit/jcbianic/flask-jeroboam
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -23,7 +23,7 @@
 [![Commit](https://img.shields.io/github/last-commit/jcbianic/flask-jeroboam?color=green)][commit]
 
 [![Read the documentation at https://flask-jeroboam.readthedocs.io/](https://img.shields.io/readthedocs/flask-jeroboam/latest.svg?label=Read%20the%20Docs)][read the docs]
-[![Coverage](https://codecov.io/gh/jcbianic/flask-jeroboam/graph/badge.svg)][codecov]
+[![Coverage](https://codecov.io/gh/jcbianic/flask-jeroboam/branch/main/graph/badge.svg)][codecov]
 [![Tests](https://github.com/jcbianic/flask-jeroboam/workflows/Tests/badge.svg)][tests]
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jcbianic/flask-jeroboam/badge)][scorecard]

--- a/README_fr.md
+++ b/README_fr.md
@@ -25,6 +25,7 @@
 [![Read the documentation at https://flask-jeroboam.readthedocs.io/](https://img.shields.io/readthedocs/flask-jeroboam/latest.svg?label=Read%20the%20Docs)][read the docs]
 [![Coverage](https://codecov.io/gh/jcbianic/flask-jeroboam/branch/main/graph/badge.svg)][codecov]
 [![Tests](https://github.com/jcbianic/flask-jeroboam/workflows/Tests/badge.svg)][tests]
+[![pre-commit](https://github.com/jcbianic/flask-jeroboam/workflows/pre-commit/badge.svg)][pre-commit-ci]
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jcbianic/flask-jeroboam/badge)][scorecard]
 
@@ -36,6 +37,7 @@
 [tests]: https://github.com/jcbianic/flask-jeroboam/actions?workflow=Tests
 [codecov]: https://app.codecov.io/gh/jcbianic/flask-jeroboam
 [pre-commit]: https://github.com/pre-commit/pre-commit
+[pre-commit-ci]: https://github.com/jcbianic/flask-jeroboam/actions/workflows/pre-commit.yml
 [ruff]: https://github.com/astral-sh/ruff
 [scorecard]: https://scorecard.dev/viewer/?uri=github.com/jcbianic/flask-jeroboam
 [commit]: https://img.shields.io/github/last-commit/jcbianic/flask-jeroboam

--- a/README_fr.md
+++ b/README_fr.md
@@ -26,6 +26,7 @@
 [![Coverage](https://codecov.io/gh/jcbianic/flask-jeroboam/graph/badge.svg)][codecov]
 [![Tests](https://github.com/jcbianic/flask-jeroboam/workflows/Tests/badge.svg)][tests]
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/jcbianic/flask-jeroboam/badge)][scorecard]
 
 [pypi_]: https://pypi.org/project/flask-jeroboam/
 [status]: https://pypi.org/project/flask-jeroboam/
@@ -36,6 +37,7 @@
 [codecov]: https://app.codecov.io/gh/jcbianic/flask-jeroboam
 [pre-commit]: https://github.com/pre-commit/pre-commit
 [ruff]: https://github.com/astral-sh/ruff
+[scorecard]: https://scorecard.dev/viewer/?uri=github.com/jcbianic/flask-jeroboam
 [commit]: https://img.shields.io/github/last-commit/jcbianic/flask-jeroboam
 
 </div>

--- a/docs/decisions/0001-accept-b-grade-complexity-ceiling.md
+++ b/docs/decisions/0001-accept-b-grade-complexity-ceiling.md
@@ -1,0 +1,89 @@
+# 0001. Accept B-grade complexity ceiling for intrinsically complex blocks
+
+**Date**: 2026-03-20
+
+**Status**: Accepted
+
+## Context
+
+During the integration of xenon complexity enforcement (issue #134), all
+functions in `flask_jeroboam/` were audited using radon. Two blocks ranked C
+(complexity 11) were refactored down to B. Three further B-ranked blocks were
+cleanly reduced to A by extracting focused helpers:
+
+- `_format_error()` extracted from `SolvedArgument.validate_request`
+- `_get_body_schema()` extracted from `_get_openapi_operation_request_body`
+- `_collect_models_from_view()` extracted from
+  `_get_flat_models_from_jeroboam_views`
+- `_unpack_body_values()` extracted from `_parse_and_validate_inbound_data`
+- `_collect_jeroboam_views()` and `_filter_definitions()` extracted from
+  `build_openapi`
+
+Nine B-ranked blocks (complexity 6-9) remained after these refactors. The
+question was whether to force all of them to A grade (complexity <= 5) to
+enable a stricter xenon threshold.
+
+## Decision
+
+Keep the xenon threshold at `--max-absolute B --max-modules B --max-average A`.
+The nine remaining B-ranked blocks are not refactored because their complexity
+is intrinsic to the problem they solve, not incidental. Forcing them to A would
+require artificial fragmentation that harms readability without improving
+correctness.
+
+The nine blocks and their justification:
+
+- **`InboundHandler._build_body_field` (9)** - Acknowledged tech debt; existing
+  TODO comments in source flag it for a future refactor.
+- **`build_openapi` (8)** - Orchestration function; extracting the loop creates
+  awkward multi-argument helpers with no semantic benefit.
+- **`SolvedArgument.validate_request` (7)** - Just refactored to B; further
+  splitting would obscure the validation flow.
+- **`OutboundHandler._adapt_datastructure_of` (7)** - Type-dispatch by design;
+  the elif chain is the correct pattern for this use case.
+- **`_unwrap_optional` (7)** - Handles two Union syntaxes (`typing.Union` and
+  `types.UnionType`); complexity is the spec, not the implementation.
+- **`_build_openapi_path_item` (7)** - Orchestration function; same
+  fragmentation risk as `build_openapi`.
+- **`InboundHandler._solve_body_field_info` (6)** - Three content-type
+  branches plus one sub-check; inherent to the logic.
+- **`_add_responses` (6)** - Two independent conditionals on different
+  concerns; no natural extraction point.
+- **`SolvedBodyArgument` class (6)** - Class-level metric reported by radon;
+  not a function that can be reduced by extraction.
+
+## Consequences
+
+### Positive
+
+- All future code is blocked at complexity B by CI; no new C or worse blocks
+  can be introduced unnoticed.
+- The nine existing blocks are documented here as deliberate exceptions, making
+  the threshold meaningful rather than arbitrary.
+- The `--max-average A` threshold remains strict, preventing overall drift even
+  if individual B blocks persist.
+
+### Negative
+
+- `InboundHandler._build_body_field` (score 9) sits close to C territory and
+  should be the first candidate for refactoring when the inbound handler is
+  revisited. Its existing TODO comments already flag this.
+- The B ceiling means a contributor adding a moderately complex function
+  (score 6-9) would not be caught by xenon, even though A is preferred.
+
+## Alternatives Considered
+
+### Force all blocks to A (--max-absolute A)
+
+Would require breaking all nine functions into smaller pieces. For type-dispatch
+functions (`_adapt_datastructure_of`) and Union-handling utilities
+(`_unwrap_optional`), this means introducing unnecessary indirection or
+restructuring code in ways that make it harder to follow. Rejected because the
+metric improvement would come at the cost of code clarity.
+
+### Keep the C threshold as baseline
+
+The initial xenon integration proposed `--max-absolute C` to match the two
+C-ranked functions that existed before refactoring. Rejected because C is too
+permissive for a library codebase and would provide weak protection against
+complexity creep.

--- a/docs_src/readme/readme01.py
+++ b/docs_src/readme/readme01.py
@@ -29,8 +29,7 @@ def ping():
 
 @app.get("/wines", response_model=list[WineOut])
 def read_wine_list(pagination: GenericPagination, search: str | None):
-    wines = get_wines(pagination, search)
-    return wines
+    return get_wines(pagination, search)
 
 
 if __name__ == "__main__":

--- a/flask_jeroboam/_inboundhandler.py
+++ b/flask_jeroboam/_inboundhandler.py
@@ -72,10 +72,9 @@ class InboundHandler:
         """Return the default FieldInfo for the InboundHandler."""
         if main_http_verb in {"POST", "PUT"}:
             return ArgumentLocation.body
-        elif main_http_verb == "GET":
+        if main_http_verb == "GET":
             return ArgumentLocation.query
-        else:
-            return ArgumentLocation.path
+        return ArgumentLocation.path
 
     @property
     def parameters(self) -> list[SolvedArgument]:
@@ -254,10 +253,9 @@ class InboundHandler:
     ) -> ArgumentLocation:
         if param_name in self.path_param_names:
             return ArgumentLocation.path
-        else:
-            return getattr(
-                param.default, "location", force_location or self.default_param_location
-            )
+        return getattr(
+            param.default, "location", force_location or self.default_param_location
+        )
 
     def _solve_default_value(
         self,

--- a/flask_jeroboam/_inboundhandler.py
+++ b/flask_jeroboam/_inboundhandler.py
@@ -30,6 +30,16 @@ T = t.TypeVar("T", bound=t.Any)
 pattern = r"(.*)\[(.+)\]$"
 
 
+def _unpack_body_values(body_value: dict) -> dict:
+    """Unpack a synthetic body model's fields back into individual view kwargs."""
+    values: dict = {}
+    for model in body_value.values():
+        if isinstance(model, BaseModel):  # pragma: no branch
+            for field_name in type(model).model_fields:
+                values[field_name] = getattr(model, field_name)
+    return values
+
+
 class InboundHandler:
     """The InboundHandler handles inbound data of a request.
 
@@ -302,12 +312,7 @@ class InboundHandler:
             body_value, body_errors = body_field.validate_request()
             errors.extend(body_errors)
             if len(self.body_arguments) > 1:
-                # Synthetic model wraps multiple params — unpack fields
-                # back into individual kwargs for the view function.
-                for model in body_value.values():
-                    if isinstance(model, BaseModel):  # pragma: no branch
-                        for field_name in type(model).model_fields:
-                            values[field_name] = getattr(model, field_name)
+                values.update(_unpack_body_values(body_value))
             else:
                 values.update(body_value)
         return values, errors

--- a/flask_jeroboam/_outboundhandler.py
+++ b/flask_jeroboam/_outboundhandler.py
@@ -118,25 +118,23 @@ class OutboundHandler:
         if isinstance(initial_return_value, tuple):
             if len(initial_return_value) == 3:
                 return initial_return_value  # type: ignore
-            elif len(initial_return_value) == 2:
+            if len(initial_return_value) == 2:
                 if isinstance(initial_return_value[1], int):
                     return (
                         initial_return_value[0],
                         initial_return_value[1],  # type:ignore
                         {},
                     )
-                else:
-                    return (
-                        initial_return_value[0],
-                        None,
-                        initial_return_value[1],  # type:ignore
-                    )
-            else:
-                raise TypeError(
-                    "The view function did not return a valid response tuple."
-                    " The tuple must have the form (body, status, headers),"
-                    " (body, status), or (body, headers)."
+                return (
+                    initial_return_value[0],
+                    None,
+                    initial_return_value[1],  # type:ignore
                 )
+            raise TypeError(
+                "The view function did not return a valid response tuple."
+                " The tuple must have the form (body, status, headers),"
+                " (body, status), or (body, headers)."
+            )
         return initial_return_value, None, None  # type: ignore
 
     def _solve_response_model(
@@ -267,11 +265,11 @@ class OutboundHandler:
         """
         if isinstance(content, dict):
             return content
-        elif isinstance(content, BaseModel):
+        if isinstance(content, BaseModel):
             return content.model_dump()
-        elif isinstance(content, list):
+        if isinstance(content, list):
             return [self._adapt_datastructure_of(item) for item in content]
-        elif dataclasses.is_dataclass(content) and not isinstance(content, type):
+        if dataclasses.is_dataclass(content) and not isinstance(content, type):
             return dataclasses.asdict(content)
 
         raise ValueError("Content must be a list, a dict, a dataclass, or a BaseModel.")

--- a/flask_jeroboam/_outboundhandler.py
+++ b/flask_jeroboam/_outboundhandler.py
@@ -250,7 +250,7 @@ class OutboundHandler:
             raise ResponseValidationError(
                 "A validation", error, traceback.format_exc()
             ) from error
-        return validated.model_dump_json()
+        return validated.model_dump_json(by_alias=True)
 
     def _adapt_datastructure_of(
         self, content: JeroboamBodyType

--- a/flask_jeroboam/exceptions.py
+++ b/flask_jeroboam/exceptions.py
@@ -85,7 +85,6 @@ class JeroboamError(Exception):
     """Base Exception for Flask-Jeroboam."""
 
 
-
 def handle_404(e):
     """Simple Hanlder for 404 errors."""
     return {"message": "Not Found"}, 404

--- a/flask_jeroboam/exceptions.py
+++ b/flask_jeroboam/exceptions.py
@@ -34,8 +34,7 @@ class RessourceNotFound(NotFound):
         """Either format message or pass the msg property."""
         if self.msg is None:
             return f"{self.ressource_name} not found : {self.context}."
-        else:
-            return self.msg
+        return self.msg
 
     def handle(self) -> tuple[str, int]:
         """Handle the exception and return a message to the user."""
@@ -85,7 +84,6 @@ class ResponseValidationError(ServerError):
 class JeroboamError(Exception):
     """Base Exception for Flask-Jeroboam."""
 
-    pass
 
 
 def handle_404(e):

--- a/flask_jeroboam/openapi/_utils.py
+++ b/flask_jeroboam/openapi/_utils.py
@@ -4,7 +4,6 @@ Credits: This is a Fork of FastAPI's openapi/utils.py
 """
 
 import warnings
-from collections.abc import Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -26,11 +25,13 @@ from flask_jeroboam._utils import (
     _throw_away_falthy_values,
     _unwrap_optional,
 )
-from flask_jeroboam.view_arguments.arguments import BodyArgument, ParameterArgument
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Sequence
+
     from flask_jeroboam.rule import JeroboamRule
     from flask_jeroboam.view import JeroboamView
+    from flask_jeroboam.view_arguments.arguments import BodyArgument, ParameterArgument
     from flask_jeroboam.view_arguments.solved import SolvedArgument
 
 
@@ -60,7 +61,7 @@ def _get_openapi_operation_parameters(
     parameters = []
     for param in all_route_params:
         field_info = param.field_info
-        field_info = cast(ParameterArgument, field_info)
+        field_info = cast("ParameterArgument", field_info)
         if getattr(param, "include_in_schema", True) is False:
             continue
         parameter = _throw_away_falthy_values(
@@ -107,14 +108,14 @@ def _get_openapi_operation_request_body(
     if body_field is None:  # pragma: no cover
         return None
     annotation = body_field.annotation
-    field_info = cast(BodyArgument, body_field.field_info)
+    field_info = cast("BodyArgument", body_field.field_info)
     request_media_type = field_info.media_type
 
     is_synthetic = _lenient_issubclass(
         annotation, BaseModel
     ) and annotation.__name__.endswith("request_body_as_model")
     if is_synthetic:
-        body_schema = cast(type[BaseModel], annotation).model_json_schema(
+        body_schema = cast("type[BaseModel]", annotation).model_json_schema(
             ref_template=REF_PREFIX + "{model}"
         )
         body_schema.pop("$defs", None)
@@ -259,9 +260,10 @@ def _get_flat_models_from_jeroboam_views(
         if response_model is not None:
             models.add(response_model)
         body_field = jeroboam_view.inbound_handler.body_field(rule.unique_id)
-        if body_field is not None and _lenient_issubclass(
-            body_field.annotation, BaseModel
+        if (
+            body_field is not None
+            and _lenient_issubclass(body_field.annotation, BaseModel)
+            and not body_field.annotation.__name__.endswith("request_body_as_model")
         ):
-            if not body_field.annotation.__name__.endswith("request_body_as_model"):
-                models.add(body_field.annotation)
+            models.add(body_field.annotation)
     return models

--- a/flask_jeroboam/openapi/_utils.py
+++ b/flask_jeroboam/openapi/_utils.py
@@ -100,8 +100,9 @@ def _get_openapi_operation_metadata(
     return operation
 
 
-def _get_body_schema(annotation: Any, body_field: "SolvedArgument") -> dict[str, Any]:
+def _get_body_schema(body_field: "SolvedArgument") -> dict[str, Any]:
     """Select the correct JSON schema representation for a request body annotation."""
+    annotation = body_field.annotation
     is_synthetic = _lenient_issubclass(
         annotation, BaseModel
     ) and annotation.__name__.endswith("request_body_as_model")
@@ -123,7 +124,7 @@ def _get_openapi_operation_request_body(
     if body_field is None:  # pragma: no cover
         return None
     field_info = cast("BodyArgument", body_field.field_info)
-    body_schema = _get_body_schema(body_field.annotation, body_field)
+    body_schema = _get_body_schema(body_field)
     request_body_oai: dict[str, Any] = {}
     if body_field.required:
         request_body_oai["required"] = True

--- a/flask_jeroboam/openapi/_utils.py
+++ b/flask_jeroboam/openapi/_utils.py
@@ -100,35 +100,34 @@ def _get_openapi_operation_metadata(
     return operation
 
 
+def _get_body_schema(annotation: Any, body_field: "SolvedArgument") -> dict[str, Any]:
+    """Select the correct JSON schema representation for a request body annotation."""
+    is_synthetic = _lenient_issubclass(
+        annotation, BaseModel
+    ) and annotation.__name__.endswith("request_body_as_model")
+    if is_synthetic:
+        body_schema = cast("type[BaseModel]", annotation).model_json_schema(
+            ref_template=REF_PREFIX + "{model}"
+        )
+        body_schema.pop("$defs", None)
+        return body_schema
+    if _lenient_issubclass(annotation, BaseModel):
+        return {"$ref": f"{REF_PREFIX}{annotation.__name__}"}
+    return body_field._type_adapter.json_schema(ref_template=REF_PREFIX + "{model}")
+
+
 def _get_openapi_operation_request_body(
     *,
     body_field: "SolvedArgument | None",
 ) -> dict[str, Any] | None:
     if body_field is None:  # pragma: no cover
         return None
-    annotation = body_field.annotation
-    field_info = cast(BodyArgument, body_field.field_info)
-    request_media_type = field_info.media_type
-
-    is_synthetic = _lenient_issubclass(
-        annotation, BaseModel
-    ) and annotation.__name__.endswith("request_body_as_model")
-    if is_synthetic:
-        body_schema = cast(type[BaseModel], annotation).model_json_schema(
-            ref_template=REF_PREFIX + "{model}"
-        )
-        body_schema.pop("$defs", None)
-    elif _lenient_issubclass(annotation, BaseModel):
-        body_schema = {"$ref": f"{REF_PREFIX}{annotation.__name__}"}
-    else:
-        body_schema = body_field._type_adapter.json_schema(
-            ref_template=REF_PREFIX + "{model}"
-        )
-
+    field_info = cast("BodyArgument", body_field.field_info)
+    body_schema = _get_body_schema(body_field.annotation, body_field)
     request_body_oai: dict[str, Any] = {}
     if body_field.required:
         request_body_oai["required"] = True
-    request_body_oai["content"] = {request_media_type: {"schema": body_schema}}
+    request_body_oai["content"] = {field_info.media_type: {"schema": body_schema}}
     return request_body_oai
 
 
@@ -246,6 +245,22 @@ def _get_model_definitions(
     return definitions
 
 
+def _collect_models_from_view(
+    jeroboam_view: "JeroboamView", rule: "JeroboamRule", models: set
+) -> None:
+    """Add response and body models from a single view to the models set."""
+    response_model = jeroboam_view.outbound_handler.response_model
+    if response_model is not None:
+        models.add(response_model)
+    body_field = jeroboam_view.inbound_handler.body_field(rule.unique_id)
+    if (
+        body_field is not None
+        and _lenient_issubclass(body_field.annotation, BaseModel)
+        and not body_field.annotation.__name__.endswith("request_body_as_model")
+    ):
+        models.add(body_field.annotation)
+
+
 def _get_flat_models_from_jeroboam_views(
     jeroboam_views: list[Optional["JeroboamView"]], rules: list["JeroboamRule"]
 ):
@@ -255,13 +270,5 @@ def _get_flat_models_from_jeroboam_views(
             continue
         if not getattr(jeroboam_view, "include_in_openapi", True):
             continue
-        response_model = jeroboam_view.outbound_handler.response_model
-        if response_model is not None:
-            models.add(response_model)
-        body_field = jeroboam_view.inbound_handler.body_field(rule.unique_id)
-        if body_field is not None and _lenient_issubclass(
-            body_field.annotation, BaseModel
-        ):
-            if not body_field.annotation.__name__.endswith("request_body_as_model"):
-                models.add(body_field.annotation)
+        _collect_models_from_view(jeroboam_view, rule, models)
     return models

--- a/flask_jeroboam/openapi/builder.py
+++ b/flask_jeroboam/openapi/builder.py
@@ -16,6 +16,25 @@ if TYPE_CHECKING:  # pragma: no cover
     from flask_jeroboam.view import JeroboamView
 
 
+def _collect_jeroboam_views(
+    app: "Jeroboam", rules: list["JeroboamRule"]
+) -> "list[JeroboamView | None]":
+    """Return the JeroboamView attached to each rule's endpoint, or None."""
+    return [
+        getattr(app.view_functions[rule.endpoint], "__jeroboam_view__", None)
+        for rule in rules
+    ]
+
+
+def _filter_definitions(definitions: dict[str, Any]) -> dict[str, Any]:
+    """Sort and strip synthetic request-body wrapper models from definitions."""
+    return {
+        k: definitions[k]
+        for k in sorted(definitions)
+        if not k.endswith("request_body_as_model")
+    }
+
+
 def build_openapi(
     *,
     app: "Jeroboam",
@@ -47,10 +66,7 @@ def build_openapi(
     operation_ids: set[str] = set()
 
     # Les jerobomas views, probablement à déléguer à l'app
-    jeroboam_views: list[JeroboamView | None] = [
-        getattr(app.view_functions[rule.endpoint], "__jeroboam_view__", None)
-        for rule in rules
-    ]
+    jeroboam_views = _collect_jeroboam_views(app, rules)
 
     # On créer des objects intermédiaires
     flat_models = _get_flat_models_from_jeroboam_views(jeroboam_views, rules)
@@ -72,11 +88,7 @@ def build_openapi(
         _memoized_update_if_value("security_schemes", security_schemes, components)
         definitions.update(path_definitions or {})
 
-    definitions = {
-        k: definitions[k]
-        for k in sorted(definitions)
-        if not k.endswith("request_body_as_model")
-    }
+    definitions = _filter_definitions(definitions)
     # On package le tout.
     return OpenAPI(
         openapi=openapi_version,

--- a/flask_jeroboam/view_arguments/solved.py
+++ b/flask_jeroboam/view_arguments/solved.py
@@ -123,23 +123,24 @@ class SolvedArgument:
         try:
             values[self.name] = self._type_adapter.validate_python(inbound_values)
         except ValidationError as exc:
-            for err in exc.errors(include_url=False):
-                loc = [self.location.value, self.alias] + [
-                    str(segment) for segment in err.get("loc", ())
-                ]
-                error_dict: dict = {
-                    "loc": loc,
-                    "msg": err["msg"],
-                    "type": err["type"],
-                }
-                if "ctx" in err:
-                    error_dict["ctx"] = {
-                        k: str(v) if isinstance(v, Exception) else v
-                        for k, v in err["ctx"].items()
-                    }
-                errors.append(error_dict)
+            errors.extend(
+                self._format_error(err) for err in exc.errors(include_url=False)
+            )
 
         return values, errors
+
+    def _format_error(self, err: dict) -> dict:
+        """Format a single pydantic ValidationError entry into the Jeroboam error shape."""
+        loc = [self.location.value, self.alias] + [
+            str(segment) for segment in err.get("loc", ())
+        ]
+        error_dict: dict = {"loc": loc, "msg": err["msg"], "type": err["type"]}
+        if "ctx" in err:
+            error_dict["ctx"] = {
+                k: str(v) if isinstance(v, Exception) else v
+                for k, v in err["ctx"].items()
+            }
+        return error_dict
 
     def _get_values(
         self,

--- a/flask_jeroboam/view_arguments/solved.py
+++ b/flask_jeroboam/view_arguments/solved.py
@@ -130,7 +130,7 @@ class SolvedArgument:
         return values, errors
 
     def _format_error(self, err: dict) -> dict:
-        """Format a single pydantic ValidationError entry into the Jeroboam error shape."""
+        """Format a pydantic ValidationError entry into the Jeroboam error shape."""
         loc = [self.location.value, self.alias] + [
             str(segment) for segment in err.get("loc", ())
         ]

--- a/noxfile.py
+++ b/noxfile.py
@@ -175,6 +175,24 @@ def xdoctest(session: nox.Session) -> None:
     session.run("python", "-m", "xdoctest", *args)
 
 
+@nox.session(python=python_versions[0])
+def xenon(session: nox.Session) -> None:
+    """Enforce code complexity thresholds with xenon.
+
+    Thresholds reflect the current baseline (two C-ranked blocks exist:
+    validate_request in solved.py and build_openapi in builder.py).
+    Reducing --max-absolute to B is a future goal tracked in #134.
+    """
+    session.install("xenon")
+    session.run(
+        "xenon",
+        "--max-absolute", "C",
+        "--max-modules", "C",
+        "--max-average", "B",
+        "flask_jeroboam/",
+    )
+
+
 @nox.session(name="docs-build", python=python_versions[0])
 def docs_build(session: nox.Session) -> None:
     """Build the documentation."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -177,18 +177,13 @@ def xdoctest(session: nox.Session) -> None:
 
 @nox.session(python=python_versions[0])
 def xenon(session: nox.Session) -> None:
-    """Enforce code complexity thresholds with xenon.
-
-    Thresholds reflect the current baseline (two C-ranked blocks exist:
-    validate_request in solved.py and build_openapi in builder.py).
-    Reducing --max-absolute to B is a future goal tracked in #134.
-    """
+    """Enforce code complexity thresholds with xenon."""
     session.install("xenon")
     session.run(
         "xenon",
-        "--max-absolute", "C",
-        "--max-modules", "C",
-        "--max-average", "B",
+        "--max-absolute", "B",
+        "--max-modules", "B",
+        "--max-average", "A",
         "flask_jeroboam/",
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
   "pytest>=6.2.5",
   "pytest-mock>=3.8.2",
   "typeguard>=4.0.0",
+  "xenon>=0.9.0",
   "xdoctest[colors]>=0.15.10",
   "pydantic[email]>=2.0",
   "email-validator>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,13 +96,16 @@ target-version = "py310"
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "N", "UP", "B", "S"]
+select = ["E", "F", "W", "I", "N", "UP", "B", "S", "C4", "C90", "RET", "PIE", "TC", "SIM", "FURB", "PERF", "RSE"]
 ignore = [
   "B008",  # Function calls in default args — intentional FastAPI-style API design
   "B905",  # zip() strict= — not enforced
   "E721",  # Type comparison with == — intentional in generic type introspection
   "N818",  # Exception name suffix — InvalidRequest is a public API name
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101", "S105", "S106", "B018", "E402", "E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,10 @@ target-version = "py310"
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "N", "UP", "B", "S", "C4", "C90", "RET", "PIE", "TC", "SIM", "FURB", "PERF", "RSE"]
+select = [
+  "E", "F", "W", "I", "N", "UP", "B", "S",
+  "C4", "C90", "RET", "PIE", "TC", "SIM", "FURB", "PERF", "RSE",
+]
 ignore = [
   "B008",  # Function calls in default args — intentional FastAPI-style API design
   "B905",  # zip() strict= — not enforced

--- a/tests/test_inbound_handler/test_inbound_model.py
+++ b/tests/test_inbound_handler/test_inbound_model.py
@@ -92,7 +92,7 @@ def test_inbound_model_parses_camel_case_directly():
     class Pagination(InboundModel):
         per_page: int = 10
 
-    instance = Pagination(**{"perPage": 25})
+    instance = Pagination(perPage=25)
     assert instance.per_page == 25
 
 
@@ -105,7 +105,7 @@ def test_inbound_model_parses_snake_case_directly():
     class Pagination(InboundModel):
         per_page: int = 10
 
-    instance = Pagination(**{"per_page": 30})
+    instance = Pagination(per_page=30)
     assert instance.per_page == 30
 
 

--- a/tests/test_inbound_handler/test_query_operations.py
+++ b/tests/test_inbound_handler/test_query_operations.py
@@ -131,4 +131,4 @@ def test_query_optionnal_base_model(
     """
     response = client.get("/query/optional_model")
     assert response.status_code == 200
-    assert response.json == OptionalModelIn(**{}).model_dump()
+    assert response.json == OptionalModelIn().model_dump()

--- a/tests/test_openapi/test_paths.py
+++ b/tests/test_openapi/test_paths.py
@@ -1198,7 +1198,7 @@ def test_paths_item(client: FlaskClient):
     assert response.status_code == 200
     return_shema = response.json
     assert return_shema
-    for path in openapi_schema["paths"].keys():  # type: ignore
+    for path in openapi_schema["paths"]:  # type: ignore
         assert (
             return_shema["paths"][path] == openapi_schema["paths"][path]  # type: ignore
         ), f"{path} don't match"

--- a/tests/test_outbound_handler/test_outbound_handler.py
+++ b/tests/test_outbound_handler/test_outbound_handler.py
@@ -144,7 +144,7 @@ def test_endpoint_can_turn_off_return_annocation(
     "type_,expected_response",
     [
         ("dict", valid_response_body),
-        ("list", [unsorted_reponse_body, unsorted_reponse_body]),
+        ("list", [valid_response_body, valid_response_body]),
         ("base_model", valid_response_body),
         ("response", valid_response_body),
         ("dataclass", valid_response_body),
@@ -157,8 +157,7 @@ def test_view_function_with_response_model_return_type(
 ):
     """GIVEN an endpoint with a response_model defined and dict return value
     WHEN hit
-    THEN it serialize the dict using the response_model
-    #TODO: find a case where it wouldn't pass without the response_model !!
+    THEN it serializes the response using the response_model, applying field aliases
     """
     response = client.get(f"/return_type/{type_}")
 


### PR DESCRIPTION
## Release 0.2.2

### Bug Fixes
- **#110** — Body field construction fails with empty string URL rules (Blueprint `url_prefix` pattern)
- **#132** — List response model items now correctly serialize with camelCase aliases (`by_alias=True` was missing from `_serialize_content` for `RootModel` wrappers)

### Quality & CI
- **#134** — Integrate xenon for code complexity threshold enforcement (max absolute B, CI-gated)
- **#137** — Activate ruff C4 (flake8-comprehensions), C90 (mccabe), RET, PIE, TC, SIM, FURB, PERF, RSE rules; zero violations
- **#142** — Fix broken Codecov and pre-commit.ci badges; add OpenSSF Scorecard workflow and badge

### Other
- ADR 0001: document accepted B-grade complexity ceiling
- Extract pre-commit into its own CI workflow with dedicated badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)