### PR TITLE
fix: resolve CI failures after 0.2.2 release merge

### DIFF
--- a/flask_jeroboam/view_arguments/solved.py
+++ b/flask_jeroboam/view_arguments/solved.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any
 
 from flask import request
 from pydantic import TypeAdapter, ValidationError
-from pydantic_core import PydanticUndefined
+from pydantic_core import ErrorDetails, PydanticUndefined
 from werkzeug.datastructures import FileStorage, Headers, MultiDict
 
 from flask_jeroboam._utils import _unwrap_optional
@@ -129,7 +129,7 @@ class SolvedArgument:
 
         return values, errors
 
-    def _format_error(self, err: dict) -> dict:
+    def _format_error(self, err: ErrorDetails) -> dict:
         """Format a pydantic ValidationError entry into the Jeroboam error shape."""
         loc = [self.location.value, self.alias] + [
             str(segment) for segment in err.get("loc", ())

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,9 +181,12 @@ def xenon(session: nox.Session) -> None:
     session.install("xenon")
     session.run(
         "xenon",
-        "--max-absolute", "B",
-        "--max-modules", "B",
-        "--max-average", "A",
+        "--max-absolute",
+        "B",
+        "--max-modules",
+        "B",
+        "--max-average",
+        "A",
         "flask_jeroboam/",
     )
 


### PR DESCRIPTION
## Summary

Two CI jobs failing on `main` after the 0.2.2 release merge:

- **pre-commit** (`ruff format`): `noxfile.py` xenon session had flag/value pairs on the same line (`"--max-absolute", "B"`). Ruff requires one argument per line. Fixed by splitting each pair.
- **mypy** (`Tests`): `SolvedArgument._format_error` was typed `err: dict` but pydantic v2's `exc.errors()` returns `list[ErrorDetails]` (a `TypedDict`), which mypy rejects as `dict[Any, Any]`. Fixed by importing `ErrorDetails` from `pydantic_core` and using it as the parameter type.

## Test plan

- [x] pre-commit CI passes (ruff format clean)
- [x] mypy CI passes on Python 3.10, 3.11, 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)