### PR TITLE
ci: fix Scorecard token-permissions and SAST findings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "30 3 * * 1"
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          languages: python
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          category: "/language:python"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   labeler:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - "v*"
 
+permissions: read-all
+
 jobs:
   release:
     name: Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,13 +6,14 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   tests:
     name: ${{ matrix.session }} ${{ matrix.python }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-      actions: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Addresses three OpenSSF Scorecard findings:

- **TokenPermissions** — Add `permissions: read-all` at the top level of `labeler.yml`, `release.yml`, and `tests.yml` (all three were missing it). Remove `actions: write` from the `tests` job in `tests.yml` (not required by `upload-artifact` v4+).
- **SAST** — Add a `codeql.yml` workflow running CodeQL for Python on every push (all branches) and every PR. This ensures all commits are covered by a recognized SAST tool, fixing the "14/30 commits checked" partial score.

## Not addressed here (require GitHub UI changes)

- **Branch Protection** — Scorecard can't read classic branch protection rules with fine-grained tokens. Fix: migrate to Repository Rulesets in Settings → Rules → Rulesets.
- **Signed-Releases** — Workflow already correct (Sigstore signing is on a separate PR). Score will improve once a release is published.

## Test plan

- [ ] Verify CodeQL workflow runs on push and PR in Actions tab
- [ ] Confirm no workflow failures from removed `actions: write` permission
- [ ] Re-run Scorecard after merge and check TokenPermissions and SAST scores improve

🤖 Generated with [Claude Code](https://claude.com/claude-code)